### PR TITLE
fix typo

### DIFF
--- a/snippets/blocks.cson
+++ b/snippets/blocks.cson
@@ -156,7 +156,7 @@
       afterEach ->
       \t$1
     """
-  'After-Each block':
+  'After-Each Async block':
     prefix: 'aftA'
     body: """
       afterEach (${1:done}) ->


### PR DESCRIPTION
Atom can no longer load cson with duplicate entries, so let's fix this typo.